### PR TITLE
feat(docs): Add notebook.css for output area styling

### DIFF
--- a/docs/source/_static/notebook.css
+++ b/docs/source/_static/notebook.css
@@ -1,0 +1,6 @@
+/* cap all output at ~15 lines, then scroll */
+/* targets nbsphinx output areas too */
+.output_area pre {
+    max-height: calc(1.2em * 15) !important;
+    overflow-y: auto         !important;
+  }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -190,7 +190,8 @@ html_context = {
     "logo_link": "index.html",  # Specify the link for the logo if needed
 }
 
-html_css_files = ["css/custom.css"]
+html_css_files = ["css/custom.css", "notebook.css"]
+
 
 html_js_files = ["js/custom.js"]
 


### PR DESCRIPTION
Introduced a new CSS file, notebook.css, to cap output areas at 15 lines and enable scrolling for better readability in Jupyter notebooks. Updated conf.py to include this new stylesheet alongside the existing custom.css, enhancing the visual presentation of output in the documentation.